### PR TITLE
Add normalizeEntityName to blueprints/ember-cli-sticky/index.js

### DIFF
--- a/blueprints/ember-cli-sticky/index.js
+++ b/blueprints/ember-cli-sticky/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   description: 'Ember addon for Sticky.js',
 
+  normalizeEntityName: function() {}, // no-op since we're just adding dependencies  
+
   afterInstall: function() {
     return this.addBowerPackageToProject('sticky');
   }


### PR DESCRIPTION
I /think/ this fixes an error message when first running `ember install ember-cli-stick` that gives a message saying generate requires an entityname to be specified. 

```
The `ember generate` command requires an entity name to be specified. For more details, use `ember help'.
```

Also part of the ember-cli docs for addons that only add 3rd party libraries to the ember app.
