### PR TITLE
Ignored code

### DIFF
--- a/app/blueprints/ember-cli-sticky.js
+++ b/app/blueprints/ember-cli-sticky.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-cli-sticky/blueprints/ember-cli-sticky';


### PR DESCRIPTION
I'm pretty sure this file is ignored/extra. 

Ember-CLI merges the addon's app folder with the main app folder, and I don't see any where ember.js or ember-cli use a blueprint folder in the `app` folder
