### PR TITLE
Prep for an Addon Dummy site

### DIFF
--- a/addon/components/sticky-container.js
+++ b/addon/components/sticky-container.js
@@ -4,11 +4,11 @@ export default Ember.Component.extend({
   tagName: 'div',
   classNames: 'sticky',
 
-  setupSticky: function() {
+  setupSticky: Ember.on('didInsertElement', function() {
     this.$().sticky({topSpacing: 0});
-  }.on('didInsertElement'),
+  }),
 
-  teardownSticky: function() {
+  teardownSticky: Ember.on('willDestroyElement', function() {
     this.$().unstick();
-  }.on('willDestroyElement'),
+  }),
 });

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "sticky": "~1.0.1"
   }
 }


### PR DESCRIPTION
Sorry to keep picking on your addon. :grinning: 

I wanted to test out ember-cli-github-pages and decided to use your addon as a guinea pig. 

Added `sticky` as a bower dependency
Refactored the Ember server to work in an Ember Addon Environment (function prototypes aren't modified with .on, .property). Even gave me trouble with the Array of data. 

Got the ember-cli-github-pages working, but more pull requests incoming... 
See: http://jhr007.github.io/ember-cli-sticky/
