### PR TITLE
Take options argument and pass it to Sticky.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember-cli-sticky
 
-Ember addon to integrate sticky.js
+Ember addon to integrate jQuery plugin [Sticky.js](http://stickyjs.com/).
 
 ## Installation
 
@@ -13,10 +13,28 @@ Ember addon to integrate sticky.js
 
 ## Usage
 
-```js
-{{#sticky-container}}
-<nav ... />
+See [Sticky.js options](https://github.com/garand/sticky#options)
+
+```hbs
+{{!  ./templates/index.hbs }}
+
+{{#sticky-container options=myStickyOptions}}
+    <nav ... />
 {{/sticky-container}}
+```
+
+
+
+```js 
+// ./controllers/index.js
+
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  myStickyOptions: {
+    topSpacing: 30 //px, default: 0
+  },
+});
 ```
 
 ## Running Tests

--- a/addon/components/sticky-container.js
+++ b/addon/components/sticky-container.js
@@ -4,9 +4,18 @@ export default Ember.Component.extend({
   tagName: 'div',
   classNames: 'sticky',
   topSpacing: 0,
+  defaultOptions: Ember.computed('topSpacing', function() {
+    return {
+      topSpacing: this.get('topSpacing')
+    };
+  }),
+
+  mergedOptions: Ember.computed('options', function() {
+    return Ember.merge( this.get('defaultOptions'), this.get('options'));
+  }),
 
   setupSticky: Ember.on('didInsertElement', function() {
-    this.$().sticky({topSpacing: this.get('topSpacing')});
+    this.$().sticky( this.get('mergedOptions') );
   }),
 
   teardownSticky: Ember.on('willDestroyElement', function() {


### PR DESCRIPTION
I wanted to use Sticky.js 's options. 

Instead of managing each Sticky.js option separately in this addon, I decided to just pass the object on to Sticky.js. This future proofs having to add an attribute if Sticky.js adds/removes an option. 

The way I refactored it shouldn't break sites using `topSpacing=123` as an argument to `sticky-container` component. `{{#sticky-container topSpacing=123}} ...`
