### PR TITLE
Pull jquery-sticky from npm instead of Bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Changed
+- Pull jQuery sticky plugin from npm instead of Bower.
 
 ## [0.4.0] - 2016-0413
 ### Changed

--- a/blueprints/ember-cli-sticky/index.js
+++ b/blueprints/ember-cli-sticky/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  description: 'Ember addon for Sticky.js',
-
-  normalizeEntityName: function() {}, // no-op since we're just adding dependencies  
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('sticky');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -9,9 +9,8 @@
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
-    "sticky": "~1.0.1"
+    "qunit": "~1.17.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,14 +4,15 @@
 module.exports = {
   name: 'ember-cli-sticky',
 
-  included: function(app) {
-    this._super.included(app);
-
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-      // If this flag is present, the addon is being built in FastBoot
-      // The jQuery plugin causes FastBoot to crash, so only import in
-      // the browser build
-      app.import(app.bowerDirectory + '/sticky/jquery.sticky.js');
+  options: {
+    nodeAssets: {
+      'jquery-sticky': function() {
+        // The jQuery plugin causes FastBoot to crash, so exclude there
+        return {
+          enabled: !process.env.EMBER_CLI_FASTBOOT,
+          import: ['jquery.sticky.js']
+        };
+      }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.6"
+    "ember-cli-htmlbars": "0.7.6",
+    "ember-cli-node-assets": "^0.1.3",
+    "jquery-sticky": "^1.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I'm on a quest to start removing Bower dependencies from our apps where possible in the ultimate hope that once [Ember itself gets addonized](https://github.com/ember-cli/ember-cli/issues/4546) we'll be able stop using Bower entirely.

This change switches ember-cli-sticky over to import the jquery-sticky library from npm, and eliminates the default blueprint that added the Bower package on install.
