### PR TITLE
Use Ember.assign when available (2.5+) to avoid deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 ### Changed
+- Fix `Ember.assign` in 2.5+ to avoid deprecations.
 - Pull jQuery sticky plugin from npm instead of Bower.
 
 ## [0.4.0] - 2016-0413

--- a/addon/components/sticky-container.js
+++ b/addon/components/sticky-container.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const assign = Ember.assign || Ember.merge;
+
 export default Ember.Component.extend({
   tagName: 'div',
   classNames: 'sticky',
@@ -11,7 +13,7 @@ export default Ember.Component.extend({
   }),
 
   mergedOptions: Ember.computed('options', function() {
-    return Ember.merge( this.get('defaultOptions'), this.get('options'));
+    return assign(this.get('defaultOptions'), this.get('options'));
   }),
 
   setupSticky: Ember.on('didInsertElement', function() {


### PR DESCRIPTION
This removed annoying deprecation in Ember 2.5+
