### PR TITLE
Trigger sticky's `update` method on `didRender`

### DIFF
--- a/addon/components/sticky-container.js
+++ b/addon/components/sticky-container.js
@@ -21,7 +21,11 @@ export default Ember.Component.extend({
   }),
 
   updateSticky: Ember.on('didRender', function() {
-    Ember.run.next(() => this.$().sticky('update'));
+    Ember.run.next(function() {
+      if (this.$().sticky) {
+        this.$().sticky('update');
+      }
+    }, this);
   }),
 
   teardownSticky: Ember.on('willDestroyElement', function() {

--- a/addon/components/sticky-container.js
+++ b/addon/components/sticky-container.js
@@ -20,6 +20,10 @@ export default Ember.Component.extend({
     this.$().sticky( this.get('mergedOptions') );
   }),
 
+  updateSticky: Ember.on('didRender', function() {
+    Ember.run.next(() => this.$().sticky('update'));
+  }),
+
   teardownSticky: Ember.on('willDestroyElement', function() {
     this.$().unstick();
   }),


### PR DESCRIPTION
If the element has dynamic content, sometimes wrapper won't update values until the user begins scrolling (e.g. `height`). This can happen even on initial load, if a piece of content finishes loading after `sticky` has been initialized.

This PR triggers sticky's built-in `update` method on re-render.